### PR TITLE
Municipio 4.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "helsingborg-stad/modularity-interactive-img-map": "~4.0.3",
     "helsingborg-stad/modularity-json-render": "~3.0.3",
     "helsingborg-stad/modularity-local-events": "~3.1.1",
-    "helsingborg-stad/modularity-open-street-map": "2.3.0",
+    "helsingborg-stad/modularity-open-street-map": "2.3.1",
     "helsingborg-stad/modularity-products": "^3.0.1",
     "helsingborg-stad/modularity-recommend": "^3.0.2",
     "helsingborg-stad/modularity-sections": "~3.0.3",

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "helsingborg-stad/modularity-timeline": "^4.0.1",
     "helsingborg-stad/multi-network-urls": "~2.0.0",
     "helsingborg-stad/multisite-role-propagation": "~3.0.5",
-    "helsingborg-stad/municipio": "5.5.2",
+    "helsingborg-stad/municipio": "5.5.17",
     "helsingborg-stad/redirection-extended": "~3.0.4",
     "helsingborg-stad/s3-uploads-custom-endpoint": "~2.0.0",
     "helsingborg-stad/search-notices": "~3.0.3",


### PR DESCRIPTION
Municipio 4.1.1 introduces several bug fixes and performance enhancements, with a particular focus on the newly released OpenStreetMap functionality and the Municipio theme.

- Municipio 5.5.17: This version optimizes overall performance by avoiding the loading of unnecessary components and implementing runtime caching.
- OpenStreetMap 2.3.5: Enhances block compatibility and adds Swedish translations.
- Styleguide 0.11.1082: Improves the positioning of floating items within the collection_item component and adds support for lazy-loaded compressed tags.