### PR TITLE
🔧fix(composer): typo in description

### DIFF
--- a/composer.local.json
+++ b/composer.local.json
@@ -1,6 +1,6 @@
 {
   "name": "municipio-se/municipio-deployment-custom",
   "license": "MIT",
-  "description": "Additions for you own install of municipo.",
+  "description": "Additions for you own install of municipio.",
   "require": {}
 }


### PR DESCRIPTION
This pull request corrects a minor typo in the project description within the `composer.local.json` file.